### PR TITLE
Add photoelectric effect simulation

### DIFF
--- a/app/simulations/photoelectric-effect/page.jsx
+++ b/app/simulations/photoelectric-effect/page.jsx
@@ -1,0 +1,15 @@
+import PhotoelectricEffect from "@/components/simulations/PhotoelectricEffect"
+
+export const metadata = {
+  title: "Photoelectric Effect Simulation",
+  description: "Interactive visualization of the photoelectric effect",
+}
+
+export default function PhotoelectricEffectPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <PhotoelectricEffect />
+    </div>
+  )
+}
+

--- a/components/HomePage.jsx
+++ b/components/HomePage.jsx
@@ -79,6 +79,13 @@ export default function HomePage() {
       icon: "🧲",
     },
     {
+      id: "photoelectric-effect",
+      title: "Photoelectric Effect",
+      description: "Simulate the photoelectric effect with adjustable light",
+      color: "from-indigo-500 to-sky-400",
+      icon: "⚡",
+    },
+    {
       id: "flappy-bird",
       title: "Not Flappy Bird",
       description: "Play an enhanced version of the classic Flappy Bird game with power-ups",

--- a/components/simulations/PhotoelectricEffect.jsx
+++ b/components/simulations/PhotoelectricEffect.jsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useRef, useState, useEffect } from "react"
+import SliderRow from "@/components/ui/SliderRow"
+
+export default function PhotoelectricEffect() {
+  const canvasRef = useRef(null)
+  const animationRef = useRef(null)
+  const electronsRef = useRef([])
+
+  const [frequency, setFrequency] = useState(500) // THz
+  const [intensity, setIntensity] = useState(50)
+  const [workFunction, setWorkFunction] = useState(2) // eV
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext("2d")
+    canvas.width = 600
+    canvas.height = 400
+
+    const h = 4.135e-15 // eV*s
+
+    const render = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      // Draw metal plate
+      ctx.fillStyle = "#888"
+      ctx.fillRect(250, 150, 20, 100)
+
+      // Draw photons
+      ctx.strokeStyle = "yellow"
+      for (let i = 0; i < intensity; i += 10) {
+        const y = 180 + Math.random() * 60
+        ctx.beginPath()
+        ctx.moveTo(0, y)
+        ctx.lineTo(250, y)
+        ctx.stroke()
+      }
+
+      const energy = h * frequency * 1e12
+      if (energy >= workFunction) {
+        for (let i = 0; i < intensity / 20; i++) {
+          electronsRef.current.push({
+            x: 260,
+            y: 180 + Math.random() * 60,
+            vx: 2 + Math.random() * 1,
+            vy: (Math.random() - 0.5) * 1,
+          })
+        }
+      }
+
+      electronsRef.current.forEach((e) => {
+        e.x += e.vx
+        e.y += e.vy
+      })
+      electronsRef.current = electronsRef.current.filter(
+        (e) => e.x < canvas.width && e.y > 0 && e.y < canvas.height
+      )
+
+      ctx.fillStyle = "#0af"
+      electronsRef.current.forEach((e) => {
+        ctx.beginPath()
+        ctx.arc(e.x, e.y, 3, 0, Math.PI * 2)
+        ctx.fill()
+      })
+
+      animationRef.current = requestAnimationFrame(render)
+    }
+
+    render()
+    return () => cancelAnimationFrame(animationRef.current)
+  }, [frequency, intensity, workFunction])
+
+  return (
+    <div className="flex flex-col lg:flex-row gap-6">
+      <div className="w-full lg:w-2/3">
+        <canvas
+          ref={canvasRef}
+          className="w-full border rounded bg-white dark:bg-gray-900"
+        />
+      </div>
+      <div className="w-full lg:w-1/3 space-y-4">
+        <h2 className="text-xl font-bold mb-2">Photoelectric Effect</h2>
+        <SliderRow
+          label="Frequency"
+          value={frequency}
+          min={100}
+          max={1000}
+          step={10}
+          onChange={setFrequency}
+          unit=" THz"
+        />
+        <SliderRow
+          label="Intensity"
+          value={intensity}
+          min={0}
+          max={100}
+          step={5}
+          onChange={setIntensity}
+        />
+        <SliderRow
+          label="Work Function"
+          value={workFunction}
+          min={1}
+          max={5}
+          step={0.1}
+          onChange={setWorkFunction}
+          unit=" eV"
+        />
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- create a new PhotoelectricEffect simulation component and page
- register the new simulation on the home page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684088dae93c8330a945cc7fe8ce5a3b